### PR TITLE
Reduce step size by half for lanes

### DIFF
--- a/convert_map.py
+++ b/convert_map.py
@@ -116,6 +116,7 @@ def convert_map(cfg: MapConversionConfig) -> None:
 
     # Convert OpenDRIVE to CommonRoad
     open_drive_config = OpenDriveConfig()
+    open_drive_config.min_delta_s = 1.0
     open_drive_config.filter_types = [
         "driving",
         # "restricted",

--- a/crdesigner/common/config/opendrive_config.py
+++ b/crdesigner/common/config/opendrive_config.py
@@ -12,7 +12,7 @@ class OpenDriveConfig(BaseConfig):
     )
 
     min_delta_s = Attribute(
-        1, "Min. delta s", "Min. step length between two sampling positions on the reference geometry"
+        0.5, "Min. delta s", "Min. step length between two sampling positions on the reference geometry"
     )
 
     precision = Attribute(0.5, "Precision", "Precision with which to convert plane group to lanelet")

--- a/crdesigner/common/config/opendrive_config.py
+++ b/crdesigner/common/config/opendrive_config.py
@@ -12,7 +12,7 @@ class OpenDriveConfig(BaseConfig):
     )
 
     min_delta_s = Attribute(
-        0.5, "Min. delta s", "Min. step length between two sampling positions on the reference geometry"
+        1, "Min. delta s", "Min. step length between two sampling positions on the reference geometry"
     )
 
     precision = Attribute(0.5, "Precision", "Precision with which to convert plane group to lanelet")

--- a/crdesigner/map_conversion/opendrive/opendrive_conversion/converter.py
+++ b/crdesigner/map_conversion/opendrive/opendrive_conversion/converter.py
@@ -155,7 +155,7 @@ class OpenDriveConverter:
                     plane_groups.append(plane_group)
 
                     if hasattr(lane, 'signal_references'):
-                        left_vertices, right_vertices = plane_group.parametric_lanes[0].calc_vertices(0, 0, None)
+                        left_vertices, right_vertices = plane_group.parametric_lanes[0].calc_vertices(0, 0.5, None)
                         plane_group.stoplines = [
                             (signal_id, left_vertices[0], right_vertices[0])
                             for signal_id in lane.signal_references

--- a/crdesigner/map_conversion/opendrive/opendrive_conversion/plane_elements/plane.py
+++ b/crdesigner/map_conversion/opendrive/opendrive_conversion/plane_elements/plane.py
@@ -280,7 +280,7 @@ class ParametricLane:
         #
         if self.length < 0:
             return np.array(left_vertices), np.array(right_vertices)
-        num_steps = int(max(3, np.ceil(self.length / float(0.5))))
+        num_steps = int(max(3, np.ceil(self.length / min_delta_s)))
         poses = np.linspace(0, self.length, num_steps)
         for s in poses:
             #


### PR DESCRIPTION
The `min_delta_s` is not currently being used by the converter and they are using a hard coded value of 0.5 meter. I tried set it to 1 and keep the same config for the signals , the resulting osm files are roughly half the size as before and the rendered visualization looks still decent. 

Below is a comparison: 

old(26.4mb): 
![visualization](https://github.com/CommonRoad/commonroad-scenario-designer/assets/22068468/09bbd5c3-0dd6-4a14-97e6-bd1342938539)

new (14.3mb):
![visualization](https://github.com/CommonRoad/commonroad-scenario-designer/assets/22068468/773c165b-dda2-4846-a115-0141464b6a9f)
