### PR TITLE
Allow arcs with negative curvature, instead of treating them as straight

### DIFF
--- a/crdesigner/map_conversion/opendrive/opendrive_parser/parser.py
+++ b/crdesigner/map_conversion/opendrive/opendrive_parser/parser.py
@@ -223,19 +223,12 @@ def parse_opendrive_road_geometry(new_road: Road, road_geometry: etree.ElementTr
             curv_end,
         )
     elif road_geometry.find("arc") is not None:
-        if float(road_geometry.find("arc").get("curvature")) > 0:
-            new_road.planView.add_arc(
-                start_coord,
-                float(road_geometry.get("hdg")) - float(offset["hdg"]),
-                float(road_geometry.get("length")),
-                float(road_geometry.find("arc").get("curvature")),
-            )
-        else:
-            new_road.planView.add_line(
-                start_coord,
-                float(road_geometry.get("hdg")) - float(offset["hdg"]),
-                float(road_geometry.get("length")),
-            )
+        new_road.planView.add_arc(
+            start_coord,
+            float(road_geometry.get("hdg")) - float(offset["hdg"]),
+            float(road_geometry.get("length")),
+            float(road_geometry.find("arc").get("curvature")),
+        )
 
     elif road_geometry.find("poly3") is not None:
         new_road.planView.add_poly3(


### PR DESCRIPTION
So apparently roads with negative curvature were silently replaced with straight lines in #7. I don't really know why, since they seem to work just fine.