### PR TITLE
Propagate elevation information to OSM

### DIFF
--- a/crdesigner/map_conversion/common/conversion_lanelet_network.py
+++ b/crdesigner/map_conversion/common/conversion_lanelet_network.py
@@ -844,7 +844,7 @@ class ConversionLaneletNetwork(LaneletNetwork):
                         # Lanelet cannot have more traffic lights than number of successors
                         if len(lane.successor) > len(lane.traffic_lights):
                             pos_1 = traffic_light.position
-                            pos_2 = lane.center_vertices[-1]
+                            pos_2 = lane.center_vertices[-1][..., :2]
                             dist = np.linalg.norm(pos_1 - pos_2)
                             if dist < min_distance:
                                 min_distance = dist
@@ -926,8 +926,8 @@ class ConversionLaneletNetwork(LaneletNetwork):
                             for index, traffic_light_id in enumerate(traffic_light_ids):
                                 traffic_light = self.find_traffic_light_by_id(traffic_light_id)
                                 traffic_light_position = traffic_light.position
-                                lanelet_left_position = target_lanelet.left_vertices[-1]
-                                lanelet_right_position = target_lanelet.right_vertices[-1]
+                                lanelet_left_position = target_lanelet.left_vertices[-1][..., :2]
+                                lanelet_right_position = target_lanelet.right_vertices[-1][..., :2]
                                 distance_from_right = np.linalg.norm(lanelet_right_position - traffic_light_position)
                                 distance_from_left = np.linalg.norm(lanelet_left_position - traffic_light_position)
                                 if distance_from_left < distance_from_right and "left" in list(
@@ -953,8 +953,8 @@ class ConversionLaneletNetwork(LaneletNetwork):
                                 traffic_light = self.find_traffic_light_by_id(traffic_light_id)
                                 # Check if traffic light is to the left of the lanelet or to the right of the lanelet
                                 traffic_light_position = traffic_light.position
-                                lanelet_left_position = target_lanelet.left_vertices[-1]
-                                lanelet_right_position = target_lanelet.right_vertices[-1]
+                                lanelet_left_position = target_lanelet.left_vertices[-1][..., :2]
+                                lanelet_right_position = target_lanelet.right_vertices[-1][..., :2]
                                 distance_from_right = np.linalg.norm(lanelet_right_position - traffic_light_position)
                                 distance_from_left = np.linalg.norm(lanelet_left_position - traffic_light_position)
                                 if distance_from_left < distance_from_right:
@@ -975,8 +975,8 @@ class ConversionLaneletNetwork(LaneletNetwork):
                                 traffic_light = self.find_traffic_light_by_id(traffic_light_id)
                                 # Check if traffic light is to the left of the lanelet or to the right of the lanelet
                                 traffic_light_position = traffic_light.position
-                                lanelet_left_position = target_lanelet.left_vertices[-1]
-                                lanelet_right_position = target_lanelet.right_vertices[-1]
+                                lanelet_left_position = target_lanelet.left_vertices[-1][..., :2]
+                                lanelet_right_position = target_lanelet.right_vertices[-1][..., :2]
                                 distance_from_right = np.linalg.norm(lanelet_right_position - traffic_light_position)
                                 distance_from_left = np.linalg.norm(lanelet_left_position - traffic_light_position)
                                 if distance_from_left < distance_from_right:
@@ -1004,7 +1004,7 @@ class ConversionLaneletNetwork(LaneletNetwork):
             for lanelet in self.lanelets:
                 # Find closest lanelet to traffic signal
                 pos_1 = traffic_sign.position
-                pos_2 = lanelet.center_vertices[0]
+                pos_2 = lanelet.center_vertices[0][..., :pos_1.shape[-1]]
                 dist = np.linalg.norm(pos_1 - pos_2)
                 if dist < min_distance:
                     min_distance = dist
@@ -1034,8 +1034,8 @@ class ConversionLaneletNetwork(LaneletNetwork):
                 for incoming in intersection.incomings:
                     for lanelet in incoming.incoming_lanelets:
                         lane = self.find_lanelet_by_id(lanelet)
-                        lanelet_position_left = lane.left_vertices[-1]
-                        lanelet_position_right = lane.right_vertices[-1]
+                        lanelet_position_left = lane.left_vertices[-1][..., :2]
+                        lanelet_position_right = lane.right_vertices[-1][..., :2]
                         stop_line_position_end = stop_line.start
                         stop_line_position_start = stop_line.end
                         if (

--- a/crdesigner/map_conversion/lanelet2/lanelet2.py
+++ b/crdesigner/map_conversion/lanelet2/lanelet2.py
@@ -62,7 +62,7 @@ class Node:
             local_y.set("v", str(self.local_y))
             node.append(local_x)
             node.append(local_y)
-        if (self.ele != "0.0" and self.ele != "0") or self.autoware:
+        if True:# (self.ele != "0.0" and self.ele != "0") or self.autoware:
             ele = etree.SubElement(node, "tag")
             ele.set("k", "ele")
             ele.set("v", self.ele)

--- a/crdesigner/map_conversion/opendrive/opendrive_conversion/converter.py
+++ b/crdesigner/map_conversion/opendrive/opendrive_conversion/converter.py
@@ -101,6 +101,7 @@ class OpenDriveConverter:
                 # outer_parametric_lane_border =
 
                 lane_borders.append(OpenDriveConverter._create_outer_lane_border(lane_borders, lane, coeff_factor))
+                lane_borders[-1].elevations = reference_border.elevations
 
                 # check the center line to save the inner linemarkings of the lanes around the center line
                 inner_linemarking = None

--- a/crdesigner/map_conversion/opendrive/opendrive_conversion/network.py
+++ b/crdesigner/map_conversion/opendrive/opendrive_conversion/network.py
@@ -194,9 +194,11 @@ class Network:
         # start_coord = np.array([transformed_start_coord[0], transformed_start_coord[1]])
         # Convert all parts of a road to parametric lanes (planes)
         for road in opendrive.roads:
+
             road.planView.precalculate()
             # The reference border is the baseline for the whole road
             reference_border = OpenDriveConverter.create_reference_border(road.planView, road.lanes.laneOffsets)
+            reference_border.elevations = road.elevationProfile.elevations
             # Extracting signals, signs and stop lines from each road
 
             # signal_references = get_traffic_signal_references(road)

--- a/crdesigner/map_conversion/opendrive/opendrive_conversion/plane_elements/border.py
+++ b/crdesigner/map_conversion/opendrive/opendrive_conversion/plane_elements/border.py
@@ -18,6 +18,7 @@ class Border:
         self.width_coefficients = []
 
         self.reference = None
+        self.elevations = None  # a sequence of polynomials describing the elevation profile, as in opendrive
 
     def _get_width_index(self, s_pos: float, is_last_pos: bool) -> float:
         """Get the index of the width which applies at position s_pos.
@@ -100,3 +101,21 @@ class Border:
         coord = ref_coord + np.array([distance * math.cos(ortho), distance * math.sin(ortho)])
 
         return coord, tang_angle, curv, max_geometry_length
+
+    def calc_elevation(self, s_pos) -> float:
+        if self.elevations is None:
+            return 0.0
+        selected_elevation = None
+        for elevation in self.elevations:
+            if elevation.start_pos > s_pos:
+                break
+            selected_elevation = elevation
+        if selected_elevation is None:
+            return 0.0
+        rel_s = s_pos - selected_elevation.start_pos
+        monomial = 1.0
+        result = 0.0
+        for coeff in selected_elevation.polynomial_coefficients:
+            result += coeff * monomial
+            monomial *= rel_s
+        return result

--- a/crdesigner/map_conversion/opendrive/opendrive_conversion/plane_elements/plane.py
+++ b/crdesigner/map_conversion/opendrive/opendrive_conversion/plane_elements/plane.py
@@ -297,6 +297,9 @@ class ParametricLane:
             else:
                 left_vertices.append(inner_pos)
                 right_vertices.append(outer_pos)
+            elevation = self.border_group.inner_border.calc_elevation(s + self.border_group.inner_border_offset)
+            left_vertices[-1] = np.concatenate([left_vertices[-1], np.array([elevation])])
+            right_vertices[-1] = np.concatenate([right_vertices[-1], np.array([elevation])])
 
             # version with sampling
             # if s >= self.length:


### PR DESCRIPTION
With this change, the elevation information from OpenDrive is now available in the Lanelet2 output using the standard `ele` tag. Note that this implementation neglects the lateral profile of the road for simplicity.